### PR TITLE
Realsense fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .vscode
 __pycache__
+yolov8m-seg.pt

--- a/yolov8_bringup/launch/yolov8_3d.launch.py
+++ b/yolov8_bringup/launch/yolov8_3d.launch.py
@@ -47,7 +47,7 @@ def generate_launch_description():
     enable_cmd = DeclareLaunchArgument(
         "enable",
         default_value="True",
-        description="Wheter to start darknet enabled")
+        description="Whether to start darknet enabled")
 
     threshold = LaunchConfiguration("threshold")
     threshold_cmd = DeclareLaunchArgument(
@@ -72,6 +72,12 @@ def generate_launch_description():
         "input_depth_info_topic",
         default_value="/camera/aligned_depth_to_color/camera_info",
         description="Name of the input depth info topic")
+    
+    depth_image_units_divisor = LaunchConfiguration("depth_image_units_divisor")
+    depth_image_units_divisor_cmd = DeclareLaunchArgument(
+        "depth_image_units_divisor",
+        default_value='1000',
+        description="Divisor used to convert the raw depth image values into metres")
 
     target_frame = LaunchConfiguration("target_frame")
     target_frame_cmd = DeclareLaunchArgument(
@@ -84,7 +90,7 @@ def generate_launch_description():
     maximum_detection_threshold_cmd = DeclareLaunchArgument(
         "maximum_detection_threshold",
         default_value="0.3",
-        description="Maximum detection threshold in the z axi")
+        description="Maximum detection threshold in the z axis")
 
     namespace = LaunchConfiguration("namespace")
     namespace_cmd = DeclareLaunchArgument(
@@ -122,7 +128,8 @@ def generate_launch_description():
         name="detect_3d_node",
         namespace=namespace,
         parameters=[{"target_frame": target_frame},
-                    {"maximum_detection_threshold", maximum_detection_threshold}],
+                    {"maximum_detection_threshold", maximum_detection_threshold},
+                    {"depth_image_units_divisor", depth_image_units_divisor}],
         remappings=[("depth_image", input_depth_topic),
                     ("depth_info", input_depth_info_topic),
                     ("detections", "tracking")]
@@ -147,6 +154,7 @@ def generate_launch_description():
     ld.add_action(input_image_topic_cmd)
     ld.add_action(input_depth_topic_cmd)
     ld.add_action(input_depth_info_topic_cmd)
+    ld.add_action(depth_image_units_divisor_cmd)
     ld.add_action(target_frame_cmd)
     ld.add_action(maximum_detection_threshold_cmd)
     ld.add_action(namespace_cmd)

--- a/yolov8_bringup/launch/yolov8_3d.launch.py
+++ b/yolov8_bringup/launch/yolov8_3d.launch.py
@@ -76,7 +76,7 @@ def generate_launch_description():
     depth_image_units_divisor = LaunchConfiguration("depth_image_units_divisor")
     depth_image_units_divisor_cmd = DeclareLaunchArgument(
         "depth_image_units_divisor",
-        default_value='1000',
+        default_value="1000",
         description="Divisor used to convert the raw depth image values into metres")
 
     target_frame = LaunchConfiguration("target_frame")
@@ -127,9 +127,9 @@ def generate_launch_description():
         executable="detect_3d_node",
         name="detect_3d_node",
         namespace=namespace,
-        parameters=[{"target_frame": target_frame},
-                    {"maximum_detection_threshold", maximum_detection_threshold},
-                    {"depth_image_units_divisor", depth_image_units_divisor}],
+        parameters=[{"target_frame": target_frame,
+                     "maximum_detection_threshold": maximum_detection_threshold,
+                     "depth_image_units_divisor": depth_image_units_divisor}],
         remappings=[("depth_image", input_depth_topic),
                     ("depth_info", input_depth_info_topic),
                     ("detections", "tracking")]

--- a/yolov8_bringup/launch/yolov8_3d.launch.py
+++ b/yolov8_bringup/launch/yolov8_3d.launch.py
@@ -15,9 +15,9 @@
 
 
 from launch import LaunchDescription
-from launch_ros.actions import Node
-from launch.substitutions import LaunchConfiguration
 from launch.actions import DeclareLaunchArgument
+from launch.substitutions import LaunchConfiguration
+from launch_ros.actions import Node
 
 
 def generate_launch_description():
@@ -60,12 +60,18 @@ def generate_launch_description():
         "input_image_topic",
         default_value="/camera/rgb/image_raw",
         description="Name of the input image topic")
-
-    input_points_topic = LaunchConfiguration("input_points_topic")
-    input_points_topic_cmd = DeclareLaunchArgument(
-        "input_points_topic",
-        default_value="/camera/depth_registered/points",
-        description="Name of the input points topic")
+    
+    input_depth_topic = LaunchConfiguration("input_depth_topic")
+    input_depth_topic_cmd = DeclareLaunchArgument(
+        "input_depth_topic",
+        default_value="/camera/aligned_depth_to_color/image_raw",
+        description="Name of the input depth topic")
+    
+    input_depth_info_topic = LaunchConfiguration("input_depth_info_topic")
+    input_depth_info_topic_cmd = DeclareLaunchArgument(
+        "input_depth_info_topic",
+        default_value="/camera/aligned_depth_to_color/camera_info",
+        description="Name of the input depth info topic")
 
     target_frame = LaunchConfiguration("target_frame")
     target_frame_cmd = DeclareLaunchArgument(
@@ -117,7 +123,8 @@ def generate_launch_description():
         namespace=namespace,
         parameters=[{"target_frame": target_frame},
                     {"maximum_detection_threshold", maximum_detection_threshold}],
-        remappings=[("points", input_points_topic),
+        remappings=[("depth_image", input_depth_topic),
+                    ("depth_info", input_depth_info_topic),
                     ("detections", "tracking")]
     )
 
@@ -138,7 +145,8 @@ def generate_launch_description():
     ld.add_action(enable_cmd)
     ld.add_action(threshold_cmd)
     ld.add_action(input_image_topic_cmd)
-    ld.add_action(input_points_topic_cmd)
+    ld.add_action(input_depth_topic_cmd)
+    ld.add_action(input_depth_info_topic_cmd)
     ld.add_action(target_frame_cmd)
     ld.add_action(maximum_detection_threshold_cmd)
     ld.add_action(namespace_cmd)

--- a/yolov8_ros/yolov8_ros/detect_3d_node.py
+++ b/yolov8_ros/yolov8_ros/detect_3d_node.py
@@ -13,7 +13,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-from typing import Tuple, List
+from typing import List, Tuple
 
 import message_filters
 import numpy as np
@@ -140,8 +140,9 @@ class Detect3DNode(Node):
             return None
 
         # find the z coordinate on the 3D BB
-        z_mean = np.nanmean(np.where(roi == 0, np.nan, roi))
-        z_diff = np.abs(roi - z_mean)
+        bb_center_z_coord = depth_image[int(center_y)][int(center_x)] / self.depth_image_units_divisor
+        z_diff = np.abs(roi - bb_center_z_coord)
+        mask_z = z_diff <= self.maximum_detection_threshold
         mask_z = z_diff <= self.maximum_detection_threshold
         if not np.any(mask_z):
             return None

--- a/yolov8_ros/yolov8_ros/detect_3d_node.py
+++ b/yolov8_ros/yolov8_ros/detect_3d_node.py
@@ -13,7 +13,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import time
 from typing import Tuple
 
 import message_filters

--- a/yolov8_ros/yolov8_ros/detect_3d_node.py
+++ b/yolov8_ros/yolov8_ros/detect_3d_node.py
@@ -76,8 +76,6 @@ class Detect3DNode(Node):
                       detections_msg: DetectionArray,
                       ) -> None:
 
-        t1 = time.time()
-        
         # check if there are detections
         if not detections_msg.detections:
             return
@@ -113,10 +111,6 @@ class Detect3DNode(Node):
 
         self._pub.publish(new_detections_msg)
 
-        t2 = time.time()
-        with open('timings.txt', "a+") as file:
-            file.write(f"{(t2 - t1) * 1000:.1f}" + "\n")
-
     def convert_bb_to_3d(self,
                          depth_image: np.ndarray,
                          depth_info: CameraInfo,
@@ -142,8 +136,8 @@ class Detect3DNode(Node):
             return None
         roi_threshold = roi[mask_z]
         z_min, z_max = np.min(roi_threshold), np.max(roi_threshold)
-        z = (z_max + z_min) / 2 
-            
+        z = (z_max + z_min) / 2
+
         # project from image to world space
         k = depth_info.k
         px, py, fx, fy = k[2], k[5], k[0], k[4]
@@ -169,7 +163,7 @@ class Detect3DNode(Node):
                                 detection: Detection
                                 ) -> KeyPoint3DArray:
 
-        # Build an array of 2d keypoints
+        # build an array of 2d keypoints
         keypoints_2d = np.array([[p.point.x, p.point.y] for p in detection.keypoints.data], dtype=np.int16)
         u = np.array(keypoints_2d[:, 1]).clip(0, depth_info.height - 1)
         v = np.array(keypoints_2d[:, 0]).clip(0, depth_info.width - 1)

--- a/yolov8_ros/yolov8_ros/detect_3d_node.py
+++ b/yolov8_ros/yolov8_ros/detect_3d_node.py
@@ -110,7 +110,8 @@ class Detect3DNode(Node):
         self._pub.publish(new_detections_msg)
 
         t2 = time.time()
-        self.get_logger().info(f"on_detect per detection: {(t2 - t1) * 1000:.1f}ms")
+        with open('timings.txt', "a") as file:
+            file.write(f"{(t2 - t1) * 1000:.1f}" + "\n")
 
     def convert_bb_to_3d(self,
                          points: np.ndarray,

--- a/yolov8_ros/yolov8_ros/detect_3d_node.py
+++ b/yolov8_ros/yolov8_ros/detect_3d_node.py
@@ -110,7 +110,7 @@ class Detect3DNode(Node):
         self._pub.publish(new_detections_msg)
 
         t2 = time.time()
-        self.get_logger().info(f"on_detect: {(t2 - t1) * 1000:0d}ms")
+        self.get_logger().info(f"on_detect per detection: {(t2 - t1) * 1000:.1f}ms")
 
     def convert_bb_to_3d(self,
                          points: np.ndarray,

--- a/yolov8_ros/yolov8_ros/detect_3d_node.py
+++ b/yolov8_ros/yolov8_ros/detect_3d_node.py
@@ -133,7 +133,6 @@ class Detect3DNode(Node):
         roi = depth_image[v_min:v_max, u_min:u_max] / self.depth_image_units_divisor  # convert to meters
         if not np.any(roi):
             return None
-        self.get_logger().info(f"{self.depth_image_units_divisor = }")
 
         # find the z coordinate on the 3D BB
         z_mean = np.nanmean(np.where(roi == 0, np.nan, roi))

--- a/yolov8_ros/yolov8_ros/detect_3d_node.py
+++ b/yolov8_ros/yolov8_ros/detect_3d_node.py
@@ -14,6 +14,7 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 
+import time
 import numpy as np
 from typing import Tuple
 
@@ -74,6 +75,8 @@ class Detect3DNode(Node):
         # check if there are detections
         if not detections_msg.detections:
             return
+        
+        t1 = time.time()
 
         transform = self.get_transform(points_msg.header.frame_id)
 
@@ -105,6 +108,9 @@ class Detect3DNode(Node):
                 new_detections_msg.detections[-1].keypoints3d = keypoints3d
 
         self._pub.publish(new_detections_msg)
+
+        t2 = time.time()
+        self.get_logger().info(f"on_detect: {(t2 - t1) * 1000:0d}ms")
 
     def convert_bb_to_3d(self,
                          points: np.ndarray,


### PR DESCRIPTION
This PR changes how the 3D bounding box and keypoint markers are calculated in `detect_3d_node`. 

The depth image and depth camera info messages are used to produce the 3D data, rather than extracting it directly from the PointCloud2 message. This is because different RGB-D camera's / ROS drivers handle the pointcloud in different ways. This change hopefully makes the package work with a broader range and cameras, as the depth image should be more consistent between manufacturers.

Initial testing results:
![image](https://github.com/mgonzs13/yolov8_ros/assets/49171824/04f78b81-1870-4180-bf26-30cac23629db)
