### PR TITLE
Requirements fix

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 opencv-python==4.8.1.78
+typing-extensions>=4.4.0
 ultralytics==8.0.202


### PR DESCRIPTION
I've found that the typing-extensions module needs to be at version 4.4.0 or greater, otherwise a number of the yolov8 nodes fail to load. Thought it's probably worth adding into the requirements.txt