### PR TITLE
Add yolov8_msgs to dependencies

### DIFF
--- a/yolov8_ros/package.xml
+++ b/yolov8_ros/package.xml
@@ -15,6 +15,7 @@
   <depend>cv_bridge</depend>
   <depend>std_srvs</depend>
   <depend>sensor_msgs</depend>
+  <depend>yolov8_msgs</depend>
 
   <export>
     <build_type>ament_python</build_type>


### PR DESCRIPTION
To fix the missing `yolov8_msgs` dependency when building with `--packages-select`.

Fixes: #42 